### PR TITLE
fix slow element access

### DIFF
--- a/clingraph/orm.py
+++ b/clingraph/orm.py
@@ -121,7 +121,7 @@ class Factbase():
         self.AttrSugar = AttrSugar
 
         self.default_graph = default_graph
-        self.fb = ClormFactBase()
+        self.fb = ClormFactBase(indexes=[Attr.element_id])
         self.prefix = prefix
 
     @classmethod


### PR DESCRIPTION
This patch sets up clorm to use an index for element access. This make the access constant instead of linear and allows for using clingraph on larger instances.

I don't know the clingraph code base very well but I think that this patch should be quite safe.