### PR TITLE
Use importlib.metadata instead of pkg_resource

### DIFF
--- a/clingraph/__init__.py
+++ b/clingraph/__init__.py
@@ -26,7 +26,7 @@ def _get_parser():
     Get the parser for the command line
     """
     # pylint: disable=anomalous-backslash-in-string
-    parser = argparse.ArgumentParser(description=textwrap.dedent("""
+    parser = argparse.ArgumentParser(description=textwrap.dedent(r"""
         _ _                         _
      __| (_)_ _  __ _ _ _ __ _ _ __| |_
     / _| | | ' \/ _` | '_/ _` | '_ \ ' \\

--- a/clingraph/__init__.py
+++ b/clingraph/__init__.py
@@ -5,7 +5,7 @@ from ast import parse
 import sys
 import argparse
 import textwrap
-import pkg_resources
+import importlib.metadata
 from .graphviz import compute_graphs, dot, render
 from .logger import setup_logger_str, COLORS
 from .orm import Factbase
@@ -14,8 +14,8 @@ from .exceptions import InvalidSyntaxJSON, InvalidSyntax
 from .clingo_utils import _get_fbs_from_encoding, _get_json, add_svg_interaction
 
 try:
-    VERSION = pkg_resources.require("clingraph")[0].version
-except pkg_resources.DistributionNotFound:
+    VERSION = importlib.metadata.version("clingraph")
+except importlib.metadata.PackageNotFoundError:
     VERSION = '0.0.0'
 
 


### PR DESCRIPTION
To address issue #101 

Note: I think importlib.metadata is introduced in Python 3.8, so would need to add a conditional import if Python 3.7 support is needed.