### PR TITLE
Possible fix at gif.py

### DIFF
--- a/clingraph/gif.py
+++ b/clingraph/gif.py
@@ -88,7 +88,7 @@ def save_gif(graphs, directory='out', name_format="movie", engine="dot", fps=1, 
 
         os.makedirs(os.path.dirname(gif_path), exist_ok=True)
 
-        duration = int(1000 * 1/fps)
+        duration = int(1000 * 1/float(fps))
         imageio.mimsave(gif_path,
                         images, duration=duration)
         paths.append({'all':gif_path})


### PR DESCRIPTION
Running the propagator example this raises an error: 

*** ERROR: (clingo): Traceback (most recent call last):                                                                                                                                                                                                                         
  File "/home/davila/miniconda2/envs/testing-clingraph/lib/python3.10/site-packages/clingo/script.py", line 233, in _pyclingo_main                                                                                                                                              
    return _pyclingo_script_main(                                                                                                                                                                                                                                               
  File "/home/davila/miniconda2/envs/testing-clingraph/lib/python3.10/site-packages/clingo/script.py", line 196, in _pyclingo_script_main                                                                                                                                       
    script.main(Control(_ffi.cast("clingo_control_t*", ctl)))                                                                                                                                                                                                                   
  File "/home/davila/miniconda2/envs/testing-clingraph/lib/python3.10/site-packages/clingo/script.py", line 151, in main                                                                                                                                                        
    __main__.main(control)  # pylint: disable=c-extension-no-member                                                                                                                                                                                                             
  File "<string>", line 90, in main                                                                                                                                                                                                                                             
  File "/home/davila/git/tmp/tmp/tmp/clingraph/clingraph/gif.py", line 91, in save_gif                                                                                                                                                                                          
    duration = int(1000 * 1/fps)                                                                                                                                                                                                                                                
TypeError: unsupported operand type(s) for /: 'int' and 'str'